### PR TITLE
Math

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -47,6 +47,7 @@
 		</meta>
 		<dc:language>en-GB</dc:language>
 		<dc:source>https://www.gutenberg.org/ebooks/12901</dc:source>
+		<dc:source>https://archive.org/details/dli.ernet.449370</dc:source>
 		<meta property="se:production-notes">This ebook corresponds to Part II of Project Gutenberg's “The Moon-Voyage,” which includes both “From the Earth to the Moon” and its sequel “Round the Moon.”</meta>
 		<meta property="se:word-count">55309</meta>
 		<meta property="se:reading-ease.flesch">63.49</meta>

--- a/src/epub/text/chapter-4.xhtml
+++ b/src/epub/text/chapter-4.xhtml
@@ -218,7 +218,7 @@
 				</p>
 			</blockquote>
 			<p>“And what does that mean?” asked Michel.</p>
-			<p>“That means,” answered Nicholl, “that the half of <var>v</var> minus <var>v</var> zero square equals <var>gr</var> multiplied by <var>r</var> upon <var>x</var> minus 1 plus <var>m</var> prime upon <var>m</var> multiplied by <var>r</var> upon <var>d</var> minus <var>x</var>, minus <var>r</var> upon <var>d</var> minus <var>x</var> minus <var>r</var>⁠—”</p>
+			<p>“That means,” answered Nicholl, “that the half of <var>v</var> square minus <var>v</var> zero square equals <var>gr</var> multiplied by <var>r</var> upon <var>x</var> minus 1 plus <var>m</var> prime upon <var>m</var> multiplied by <var>r</var> upon <var>d</var> minus <var>x</var>, minus <var>r</var> upon <var>d</var> minus <var>r</var>⁠—”</p>
 			<p class="continued">“<var>x</var> upon <var>y</var> galloping upon <var>z</var> and rearing upon <var>p</var>,” cried Michel Ardan, bursting out laughing. “Do you mean to say you understand that, captain?”</p>
 			<p>“Nothing is clearer.”</p>
 			<p>“Then,” said Michel Ardan, “it is as plain as a pikestaff, and I want nothing more.”</p>

--- a/src/epub/text/chapter-4.xhtml
+++ b/src/epub/text/chapter-4.xhtml
@@ -244,7 +244,7 @@
 			<p>“That I understand.”</p>
 			<p class="continued">“<var>r</var> is the radius of the earth.”</p>
 			<p class="continued">“<var>r</var>, radius; admitted.”</p>
-			<p class="continued">“<var>m</var> is the volume of the earth; <var>m prime</var> that of the moon. We are obliged to take into account the volume of the two attracting bodies, as the attraction is in proportion to the volume.”</p>
+			<p class="continued">“<var>m</var> is the volume of the earth; <var>m</var> prime that of the moon. We are obliged to take into account the volume of the two attracting bodies, as the attraction is in proportion to the volume.”</p>
 			<p>“I understand that.”</p>
 			<p class="continued">“<var>g</var> represents gravity, the speed acquired at the end of a second by a body falling on the surface of the earth. Is that clear?”</p>
 			<p>“A mountain stream!” answered Michel.</p>
@@ -271,7 +271,7 @@
 			<p>“And <var>g</var>, the gravity, is to Florida 9¹⁄₈₁ metres. From whence it results that <var>gr</var> equals⁠—”</p>
 			<p>“Sixty-two million four hundred and twenty-six thousand square metres,” answered Nicholl.</p>
 			<p>“What next?” asked Michel Ardan.</p>
-			<p>“Now that the expressions are reduced to figures, I am going to find the velocity <var>v zero</var>⁠—that is to say, the velocity that the projectile ought to have on leaving the atmosphere to reach the point of equal attraction with no velocity. The velocity at that point I make equal zero, and <var>x</var>, the distance where the neutral point is, will be represented by the nine-tenths of <var>d</var>⁠—that is to say, the distance that separates the two centres.”</p>
+			<p>“Now that the expressions are reduced to figures, I am going to find the velocity <var>v</var> zero⁠—that is to say, the velocity that the projectile ought to have on leaving the atmosphere to reach the point of equal attraction with no velocity. The velocity at that point I make equal zero, and <var>x</var>, the distance where the neutral point is, will be represented by the nine-tenths of <var>d</var>⁠—that is to say, the distance that separates the two centres.”</p>
 			<p>“I have some vague idea that it ought to be so,” said Michel.</p>
 			<p>“I shall then have, <var>x</var> equals nine-tenths of <var>d</var>, and <var>v</var> equals zero, and my formula will become⁠—”</p>
 			<p>Barbicane wrote rapidly on the paper⁠—</p>
@@ -425,7 +425,7 @@
 			<p>“Clever fellows!” murmured Michel.</p>
 			<p>“Do you understand now?” asked Barbicane.</p>
 			<p>“If I understand!” cried Michel Ardan. “My head is bursting with it.”</p>
-			<p>“Thus,” resumed Barbicane, “<var>v zero</var> square equals 2 <var>gr</var> multiplied by 1 minus 10 <var>r</var> upon 9 <var>d</var> minus ¹⁄₈₁ multiplied by 10 <var>r</var> upon <var>d</var> minus <var>r</var> upon <var>d</var> minus <var>r</var>.”</p>
+			<p>“Thus,” resumed Barbicane, “<var>v</var> zero square equals 2 <var>gr</var> multiplied by 1 minus 10 <var>r</var> upon 9 <var>d</var> minus ¹⁄₈₁ multiplied by 10 <var>r</var> upon <var>d</var> minus <var>r</var> upon <var>d</var> minus <var>r</var>.”</p>
 			<p>“And now,” said Nicholl, “in order to obtain the velocity of the bullet as it emerges from the atmosphere I have only to calculate.”</p>
 			<p>The captain, like a man used to overcome all difficulties, began to calculate with frightful rapidity. Divisions and multiplications grew under his fingers. Figures dotted the page. Barbicane followed him with his eyes, whilst Michel Ardan compressed a coming headache with his two hands.</p>
 			<p>“Well, what do you make it?” asked Barbicane after several minutes’ silence.</p>

--- a/src/epub/text/chapter-4.xhtml
+++ b/src/epub/text/chapter-4.xhtml
@@ -63,70 +63,157 @@
 			<blockquote>
 				<p>
 					<m:math alttext="1/2⁢(v² - v₀²) = g⁢r⁢{r/x - 1 + m′/m⁢(r/(d - x) - r/(d - r))}">
-						<m:mrow>
-							<m:mfrac>
-								<m:mn>1</m:mn>
-								<m:mn>2</m:mn>
-							</m:mfrac>
-							<m:mo>⁢</m:mo>
-							<m:mo fence="true">(</m:mo>
-							<m:msup>
-								<m:mi>v</m:mi>
-								<m:mn>2</m:mn>
-							</m:msup>
-							<m:mo>−</m:mo>
-							<m:msup>
-								<m:msub>
-									<m:mi>v</m:mi>
-									<m:mn>0</m:mn>
-								</m:msub>
-								<m:mn>2</m:mn>
-							</m:msup>
-							<m:mo fence="true">)</m:mo>
-							<m:mo>=</m:mo>
-							<m:mi>g</m:mi>
-							<m:mo>⁢</m:mo>
-							<m:mi>r</m:mi>
-							<m:mo>⁢</m:mo>
+						<m:semantics>
 							<m:mrow>
-								<m:mo fence="true">{</m:mo>
 								<m:mfrac>
-									<m:mi>r</m:mi>
-									<m:mi>x</m:mi>
-								</m:mfrac>
-								<m:mo>-</m:mo>
-								<m:mn>1</m:mn>
-								<m:mo>+</m:mo>
-								<m:mfrac>
-									<m:msup>
-										<m:mi>m</m:mi>
-										<m:mo>′</m:mo>
-									</m:msup>
-									<m:mi>m</m:mi>
+									<m:mn>1</m:mn>
+									<m:mn>2</m:mn>
 								</m:mfrac>
 								<m:mo>⁢</m:mo>
 								<m:mo fence="true">(</m:mo>
-								<m:mfrac>
-									<m:mi>r</m:mi>
-									<m:mrow>
-										<m:mi>d</m:mi>
-										<m:mo>−</m:mo>
-										<m:mi>x</m:mi>
-									</m:mrow>
-								</m:mfrac>
+								<m:msup>
+									<m:mi>v</m:mi>
+									<m:mn>2</m:mn>
+								</m:msup>
 								<m:mo>−</m:mo>
-								<m:mfrac>
-									<m:mi>r</m:mi>
-									<m:mrow>
-										<m:mi>d</m:mi>
-										<m:mo>−</m:mo>
-										<m:mi>r</m:mi>
-									</m:mrow>
-								</m:mfrac>
+								<m:msup>
+									<m:msub>
+										<m:mi>v</m:mi>
+										<m:mn>0</m:mn>
+									</m:msub>
+									<m:mn>2</m:mn>
+								</m:msup>
 								<m:mo fence="true">)</m:mo>
-								<m:mo fence="true">}</m:mo>
+								<m:mo>=</m:mo>
+								<m:mi>g</m:mi>
+								<m:mo>⁢</m:mo>
+								<m:mi>r</m:mi>
+								<m:mo>⁢</m:mo>
+								<m:mrow>
+									<m:mo fence="true">{</m:mo>
+									<m:mfrac>
+										<m:mi>r</m:mi>
+										<m:mi>x</m:mi>
+									</m:mfrac>
+									<m:mo>-</m:mo>
+									<m:mn>1</m:mn>
+									<m:mo>+</m:mo>
+									<m:mfrac>
+										<m:msup>
+											<m:mi>m</m:mi>
+											<m:mo>′</m:mo>
+										</m:msup>
+										<m:mi>m</m:mi>
+									</m:mfrac>
+									<m:mo>⁢</m:mo>
+									<m:mo fence="true">(</m:mo>
+									<m:mfrac>
+										<m:mi>r</m:mi>
+										<m:mrow>
+											<m:mi>d</m:mi>
+											<m:mo>−</m:mo>
+											<m:mi>x</m:mi>
+										</m:mrow>
+									</m:mfrac>
+									<m:mo>−</m:mo>
+									<m:mfrac>
+										<m:mi>r</m:mi>
+										<m:mrow>
+											<m:mi>d</m:mi>
+											<m:mo>−</m:mo>
+											<m:mi>r</m:mi>
+										</m:mrow>
+									</m:mfrac>
+									<m:mo fence="true">)</m:mo>
+									<m:mo fence="true">}</m:mo>
+								</m:mrow>
 							</m:mrow>
-						</m:mrow>
+							<m:annotation-xml encoding="Content-MathML">
+								<m:apply>
+									<m:eq/>
+									<m:apply>
+										<m:times/>
+										<m:apply>
+											<m:divide/>
+											<m:cn type="integer">1</m:cn>
+											<m:cn type="integer">2</m:cn>
+										</m:apply>
+										<m:apply>
+											<m:minus/>
+											<m:apply>
+												<m:power/>
+												<m:ci type="real">v</m:ci>
+												<m:cn type="integer">2</m:cn>
+											</m:apply>
+											<m:apply>
+												<m:power/>
+												<m:ci type="real">
+													<m:msub>
+														<m:mi>v</m:mi>
+														<m:mn>0</m:mn>
+													</m:msub>
+												</m:ci>
+												<m:cn type="integer">2</m:cn>
+											</m:apply>
+										</m:apply>
+									</m:apply>
+									<m:apply>
+										<m:times/>
+										<m:apply>
+											<m:times/>
+											<m:ci type="real">g</m:ci>
+											<m:ci type="real">r</m:ci>
+										</m:apply>
+										<m:apply>
+											<m:plus/>
+											<m:apply>
+												<m:minus/>
+												<m:apply>
+													<m:divide/>
+													<m:ci type="real">r</m:ci>
+													<m:ci type="real">x</m:ci>
+												</m:apply>
+												<m:cn type="integer">1</m:cn>
+											</m:apply>
+											<m:apply>
+												<m:times/>
+												<m:apply>
+													<m:divide/>
+													<m:ci type="real">
+														<m:msup>
+															<m:mi>m</m:mi>
+															<m:mo>′</m:mo>
+														</m:msup>
+													</m:ci>
+													<m:ci type="real">m</m:ci>
+												</m:apply>
+												<m:apply>
+													<m:minus/>
+													<m:apply>
+														<m:divide/>
+														<m:ci type="real">r</m:ci>
+														<m:apply>
+															<m:minus/>
+															<m:ci type="real">d</m:ci>
+															<m:ci type="real">x</m:ci>
+														</m:apply>
+													</m:apply>
+													<m:apply>
+														<m:divide/>
+														<m:ci type="real">r</m:ci>
+														<m:apply>
+															<m:minus/>
+															<m:ci type="real">d</m:ci>
+															<m:ci type="real">r</m:ci>
+														</m:apply>
+													</m:apply>
+												</m:apply>
+											</m:apply>
+										</m:apply>
+									</m:apply>
+								</m:apply>
+							</m:annotation-xml>
+						</m:semantics>
 					</m:math>
 				</p>
 			</blockquote>
@@ -191,65 +278,143 @@
 			<blockquote>
 				<p>
 					<m:math alttext="v₀² = 2⁢g⁢r⁢{1 - 10⁢r/(9⁢d) - 1⁄81 (10⁢r/d - r/(d - r))}">
-						<m:mrow>
-							<m:msup>
-								<m:msub>
-									<m:mi>v</m:mi>
-									<m:mn>0</m:mn>
-								</m:msub>
-								<m:mn>2</m:mn>
-							</m:msup>
-							<m:mo>=</m:mo>
-							<m:mn>2</m:mn>
-							<m:mo>⁢</m:mo>
-							<m:mi>g</m:mi>
-							<m:mo>⁢</m:mo>
-							<m:mi>r</m:mi>
-							<m:mo>⁢</m:mo>
+						<m:semantics>
 							<m:mrow>
-								<m:mo fence="true">{</m:mo>
-								<m:mn>1</m:mn>
-								<m:mo>−</m:mo>
-								<m:mfrac>
-									<m:mrow>
-										<m:mn>10</m:mn>
-										<m:mo>⁢</m:mo>
-										<m:mi>r</m:mi>
-									</m:mrow>
-									<m:mrow>
-										<m:mn>9</m:mn>
-										<m:mo>⁢</m:mo>
-										<m:mi>d</m:mi>
-									</m:mrow>
-								</m:mfrac>
-								<m:mo>−</m:mo>
-								<m:mfrac>
-									<m:mi>1</m:mi>
-									<m:mi>81</m:mi>
-								</m:mfrac>
+								<m:msup>
+									<m:msub>
+										<m:mi>v</m:mi>
+										<m:mn>0</m:mn>
+									</m:msub>
+									<m:mn>2</m:mn>
+								</m:msup>
+								<m:mo>=</m:mo>
+								<m:mn>2</m:mn>
 								<m:mo>⁢</m:mo>
-								<m:mo fence="true">(</m:mo>
-								<m:mfrac>
-									<m:mrow>
-										<m:mn>10</m:mn>
-										<m:mo>⁢</m:mo>
-										<m:mi>r</m:mi>
-									</m:mrow>
-									<m:mi>d</m:mi>
-								</m:mfrac>
-								<m:mo>−</m:mo>
-								<m:mfrac>
-									<m:mi>r</m:mi>
-									<m:mrow>
+								<m:mi>g</m:mi>
+								<m:mo>⁢</m:mo>
+								<m:mi>r</m:mi>
+								<m:mo>⁢</m:mo>
+								<m:mrow>
+									<m:mo fence="true">{</m:mo>
+									<m:mn>1</m:mn>
+									<m:mo>−</m:mo>
+									<m:mfrac>
+										<m:mrow>
+											<m:mn>10</m:mn>
+											<m:mo>⁢</m:mo>
+											<m:mi>r</m:mi>
+										</m:mrow>
+										<m:mrow>
+											<m:mn>9</m:mn>
+											<m:mo>⁢</m:mo>
+											<m:mi>d</m:mi>
+										</m:mrow>
+									</m:mfrac>
+									<m:mo>−</m:mo>
+									<m:mfrac>
+										<m:mi>1</m:mi>
+										<m:mi>81</m:mi>
+									</m:mfrac>
+									<m:mo>⁢</m:mo>
+									<m:mo fence="true">(</m:mo>
+									<m:mfrac>
+										<m:mrow>
+											<m:mn>10</m:mn>
+											<m:mo>⁢</m:mo>
+											<m:mi>r</m:mi>
+										</m:mrow>
 										<m:mi>d</m:mi>
-										<m:mo>−</m:mo>
+									</m:mfrac>
+									<m:mo>−</m:mo>
+									<m:mfrac>
 										<m:mi>r</m:mi>
-									</m:mrow>
-								</m:mfrac>
-								<m:mo fence="true">)</m:mo>
-								<m:mo fence="true">}</m:mo>
+										<m:mrow>
+											<m:mi>d</m:mi>
+											<m:mo>−</m:mo>
+											<m:mi>r</m:mi>
+										</m:mrow>
+									</m:mfrac>
+									<m:mo fence="true">)</m:mo>
+									<m:mo fence="true">}</m:mo>
+								</m:mrow>
 							</m:mrow>
-						</m:mrow>
+							<m:annotation-xml encoding="Content-MathML">
+								<m:apply>
+									<m:eq/>
+									<m:apply>
+										<m:power/>
+										<m:ci type="real">
+											<m:msub>
+												<m:mi>v</m:mi>
+												<m:mn>0</m:mn>
+											</m:msub>
+										</m:ci>
+										<m:cn type="integer">2</m:cn>
+									</m:apply>
+									<m:apply>
+										<m:times/>
+										<m:apply>
+											<m:times/>
+											<m:cn type="integer">2</m:cn>
+											<m:apply>
+												<m:times/>
+												<m:ci type="real">g</m:ci>
+												<m:ci type="real">r</m:ci>
+											</m:apply>
+										</m:apply>
+										<m:apply>
+											<m:minus/>
+											<m:apply>
+												<m:minus/>
+												<m:cn type="integer">1</m:cn>
+												<m:apply>
+													<m:divide/>
+													<m:apply>
+														<m:times/>
+														<m:cn type="integer">10</m:cn>
+														<m:ci type="real">r</m:ci>
+													</m:apply>
+													<m:apply>
+														<m:times/>
+														<m:cn type="integer">9</m:cn>
+														<m:ci type="real">d</m:ci>
+													</m:apply>
+												</m:apply>
+											</m:apply>
+											<m:apply>
+												<m:times/>
+												<m:apply>
+													<m:divide/>
+													<m:cn type="integer">1</m:cn>
+													<m:cn type="integer">81</m:cn>
+												</m:apply>
+												<m:apply>
+													<m:minus/>
+													<m:apply>
+														<m:divide/>
+														<m:apply>
+															<m:times/>
+															<m:cn type="integer">10</m:cn>
+															<m:ci type="real">r</m:ci>
+														</m:apply>
+														<m:ci type="real">d</m:ci>
+													</m:apply>
+													<m:apply>
+														<m:divide/>
+														<m:ci type="real">r</m:ci>
+														<m:apply>
+															<m:minus/>
+															<m:ci type="real">d</m:ci>
+															<m:ci type="real">r</m:ci>
+														</m:apply>
+													</m:apply>
+												</m:apply>
+											</m:apply>
+										</m:apply>
+									</m:apply>
+								</m:apply>
+							</m:annotation-xml>
+						</m:semantics>
 					</m:math>
 				</p>
 			</blockquote>

--- a/src/epub/text/chapter-4.xhtml
+++ b/src/epub/text/chapter-4.xhtml
@@ -62,7 +62,7 @@
 			<p>Half-an-hour had not elapsed before Barbicane, raising his head, showed Michel Ardan a page covered with algebraical signs, amidst which the following general formula was discernible:⁠—</p>
 			<blockquote>
 				<p>
-					<m:math alttext="½(v^2 - v₀^2) = gr{r/x - 1 + m'/m[r/(d - x) - (r/(d - r)]}">
+					<m:math alttext="½(v^2 - v₀^2) = gr{r/x - 1 + m'/m[r/(d - x) - r/(d - r)]}">
 						<m:mrow>
 							<m:mfrac>
 								<m:mn>1</m:mn>

--- a/src/epub/text/chapter-4.xhtml
+++ b/src/epub/text/chapter-4.xhtml
@@ -115,10 +115,10 @@
 			</blockquote>
 			<p>“And what does that mean?” asked Michel.</p>
 			<p>“That means,” answered Nicholl, “that the half of <var>v</var> minus <var>v</var> zero square equals <var>gr</var> multiplied by <var>r</var> upon <var>x</var> minus 1 plus <var>m</var> prime upon <var>m</var> multiplied by <var>r</var> upon <var>d</var> minus <var>x</var>, minus <var>r</var> upon <var>d</var> minus <var>x</var> minus <var>r</var>⁠—”</p>
-			<p class="continued">“<var>x</var> upon <var>y</var> galloping upon <var>z</var> and rearing upon <var>p</var>” cried Michel Ardan, bursting out laughing. “Do you mean to say you understand that, captain?”</p>
+			<p class="continued">“<var>x</var> upon <var>y</var> galloping upon <var>z</var> and rearing upon <var>p</var>,” cried Michel Ardan, bursting out laughing. “Do you mean to say you understand that, captain?”</p>
 			<p>“Nothing is clearer.”</p>
 			<p>“Then,” said Michel Ardan, “it is as plain as a pikestaff, and I want nothing more.”</p>
-			<p>“Everlasting laugher,” said Barbicane, “you wanted algebra, and now you shall have it over head and ears.”</p>
+			<p>“Everlasting laughter,” said Barbicane, “you wanted algebra, and now you shall have it over head and ears.”</p>
 			<p>“I would rather be hung!”</p>
 			<p>“That appears a good solution, Barbicane,” said Nicholl, who was examining the formula like a <i xml:lang="fr">connaisseur</i>. “It is the integral of the equation of ‘vis viva,’ and I do not doubt that it will give us the desired result.”</p>
 			<p>“But I should like to understand!” exclaimed Michel. “I would give ten years of Nicholl’s life to understand!”</p>

--- a/src/epub/text/chapter-4.xhtml
+++ b/src/epub/text/chapter-4.xhtml
@@ -62,7 +62,7 @@
 			<p>Half-an-hour had not elapsed before Barbicane, raising his head, showed Michel Ardan a page covered with algebraical signs, amidst which the following general formula was discernible:⁠—</p>
 			<blockquote>
 				<p>
-					<m:math alttext="½(v^2 - v₀^2) = gr{r/x - 1 + m'/m[r/(d - x) - r/(d - r)]}">
+					<m:math alttext="1/2⁢(v² - v₀²) = g⁢r⁢{r/x - 1 + m′/m⁢(r/(d - x) - r/(d - r))}">
 						<m:mrow>
 							<m:mfrac>
 								<m:mn>1</m:mn>
@@ -190,7 +190,7 @@
 			<p>Barbicane wrote rapidly on the paper⁠—</p>
 			<blockquote>
 				<p>
-					<m:math alttext="v₀^2 = 2gr{1 - 10r/(9d) - ¹⁄₈₁ [10r/d - r/(d - r)]}">
+					<m:math alttext="v₀² = 2⁢g⁢r⁢{1 - 10⁢r/(9⁢d) - 1⁄81 (10⁢r/d - r/(d - r))}">
 						<m:mrow>
 							<m:msup>
 								<m:msub>

--- a/src/epub/text/chapter-4.xhtml
+++ b/src/epub/text/chapter-4.xhtml
@@ -66,23 +66,28 @@
 						<m:mrow>
 							<m:mfrac>
 								<m:mn>1</m:mn>
-								<m:mi>2</m:mi>
+								<m:mn>2</m:mn>
 							</m:mfrac>
+							<m:mo>⁢</m:mo>
 							<m:mo fence="true">(</m:mo>
 							<m:msup>
 								<m:mi>v</m:mi>
 								<m:mn>2</m:mn>
 							</m:msup>
 							<m:mo>−</m:mo>
-							<m:msubsup>
-								<m:mi>v</m:mi>
-								<m:mn>0</m:mn>
+							<m:msup>
+								<m:msub>
+									<m:mi>v</m:mi>
+									<m:mn>0</m:mn>
+								</m:msub>
 								<m:mn>2</m:mn>
-							</m:msubsup>
+							</m:msup>
 							<m:mo fence="true">)</m:mo>
 							<m:mo>=</m:mo>
 							<m:mi>g</m:mi>
+							<m:mo>⁢</m:mo>
 							<m:mi>r</m:mi>
+							<m:mo>⁢</m:mo>
 							<m:mrow>
 								<m:mo fence="true">{</m:mo>
 								<m:mfrac>
@@ -93,18 +98,30 @@
 								<m:mn>1</m:mn>
 								<m:mo>+</m:mo>
 								<m:mfrac>
-									<m:mi>m’</m:mi>
+									<m:msup>
+										<m:mi>m</m:mi>
+										<m:mo>′</m:mo>
+									</m:msup>
 									<m:mi>m</m:mi>
 								</m:mfrac>
+								<m:mo>⁢</m:mo>
 								<m:mo fence="true">(</m:mo>
 								<m:mfrac>
 									<m:mi>r</m:mi>
-									<m:mi>d − x</m:mi>
+									<m:mrow>
+										<m:mi>d</m:mi>
+										<m:mo>−</m:mo>
+										<m:mi>x</m:mi>
+									</m:mrow>
 								</m:mfrac>
 								<m:mo>−</m:mo>
 								<m:mfrac>
 									<m:mi>r</m:mi>
-									<m:mi>d − r</m:mi>
+									<m:mrow>
+										<m:mi>d</m:mi>
+										<m:mo>−</m:mo>
+										<m:mi>r</m:mi>
+									</m:mrow>
 								</m:mfrac>
 								<m:mo fence="true">)</m:mo>
 								<m:mo fence="true">}</m:mo>
@@ -175,37 +192,59 @@
 				<p>
 					<m:math alttext="v₀^2 = 2gr{1 - 10r/(9d) - ¹⁄₈₁ [10r/d - r/(d - r)]}">
 						<m:mrow>
-							<m:msubsup>
-								<m:mi>v</m:mi>
-								<m:mn>0</m:mn>
+							<m:msup>
+								<m:msub>
+									<m:mi>v</m:mi>
+									<m:mn>0</m:mn>
+								</m:msub>
 								<m:mn>2</m:mn>
-							</m:msubsup>
+							</m:msup>
 							<m:mo>=</m:mo>
 							<m:mn>2</m:mn>
+							<m:mo>⁢</m:mo>
 							<m:mi>g</m:mi>
+							<m:mo>⁢</m:mo>
 							<m:mi>r</m:mi>
+							<m:mo>⁢</m:mo>
 							<m:mrow>
 								<m:mo fence="true">{</m:mo>
 								<m:mn>1</m:mn>
 								<m:mo>−</m:mo>
 								<m:mfrac>
-									<m:mi>10r</m:mi>
-									<m:mi>9d</m:mi>
+									<m:mrow>
+										<m:mn>10</m:mn>
+										<m:mo>⁢</m:mo>
+										<m:mi>r</m:mi>
+									</m:mrow>
+									<m:mrow>
+										<m:mn>9</m:mn>
+										<m:mo>⁢</m:mo>
+										<m:mi>d</m:mi>
+									</m:mrow>
 								</m:mfrac>
 								<m:mo>−</m:mo>
 								<m:mfrac>
 									<m:mi>1</m:mi>
 									<m:mi>81</m:mi>
 								</m:mfrac>
+								<m:mo>⁢</m:mo>
 								<m:mo fence="true">(</m:mo>
 								<m:mfrac>
-									<m:mi>10r</m:mi>
+									<m:mrow>
+										<m:mn>10</m:mn>
+										<m:mo>⁢</m:mo>
+										<m:mi>r</m:mi>
+									</m:mrow>
 									<m:mi>d</m:mi>
 								</m:mfrac>
 								<m:mo>−</m:mo>
 								<m:mfrac>
 									<m:mi>r</m:mi>
-									<m:mi>d − r</m:mi>
+									<m:mrow>
+										<m:mi>d</m:mi>
+										<m:mo>−</m:mo>
+										<m:mi>r</m:mi>
+									</m:mrow>
 								</m:mfrac>
 								<m:mo fence="true">)</m:mo>
 								<m:mo fence="true">}</m:mo>


### PR DESCRIPTION
The scan I found is of the same translation, but probably a different edition than our transcription. I say so because the paragraph describing the first equation in our edition (which is wrong) doesn’t match the same paragraph in the scan (which is also wrong).

- SE says: “the half of <var>v</var> minus <var>v</var> zero square equals <var>gr</var> multiplied by <var>r</var> upon <var>x</var> minus 1 plus <var>m</var> prime upon <var>m</var> multiplied by <var>r</var> upon <var>d</var> minus <var>x</var>, minus <var>r</var> upon <var>d</var> **minus <var>x</var>** minus <var>r</var>”
- The scan says: “the half of <var>v</var> minus <var>v</var> zero square equals <var>gr</var> multiplied by <var>r</var> upon <var>x</var> **square** minus 1 plus <var>m</var> prime upon <var>m</var> multiplied by <var>r</var> upon <var>d</var> minus <var>x</var>, minus <var>r</var> upon <var>d</var> minus <var>r</var>”
- The correct equation is: “the half of <var>v</var> **square** minus <var>v</var> zero square equals <var>gr</var> multiplied by <var>r</var> upon <var>x</var> minus 1 plus <var>m</var> prime upon <var>m</var> multiplied by <var>r</var> upon <var>d</var> minus <var>x</var>, minus <var>r</var> upon <var>d</var> minus <var>r</var>”